### PR TITLE
Make File and FileContent less file system dependent

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1,7 +1,7 @@
-use std::{fmt::Display, fs, path::PathBuf};
+use std::{fmt::Display, fs, io::Write, path::PathBuf};
 
 use crate::{
-    encoding::{decode_utf16be, decode_utf16le, decode_utf8_with_bom, Encoding},
+    encoding::{to_utf16_be, to_utf16_le, to_utf8_bom, Encoding},
     text_data::TextData,
 };
 
@@ -11,14 +11,31 @@ pub enum FileContent {
     Binary { content: Vec<u8> },
 }
 
+impl FileContent {
+    pub fn write<T: Write>(&self, writer: &mut T) -> Result<(), std::io::Error> {
+        match self {
+            FileContent::Encoded { content } => match content.encoding {
+                Encoding::Utf8 => writer.write_all(content.data.as_bytes()),
+                Encoding::Utf8Bom => writer.write_all(&to_utf8_bom(&content.data)),
+                Encoding::Utf16Be => writer.write_all(&to_utf16_be(&content.data)),
+                Encoding::Utf16Le => writer.write_all(&to_utf16_le(&content.data)),
+            },
+            FileContent::Binary { content } => writer.write_all(content),
+        }
+    }
+}
+
+/// A file representation that can be used to pair a file path with its content.
+/// [File] provides convenience methods for working with files on disk, or in memory.
 #[derive(Debug, PartialEq)]
 pub struct File {
     pub path: PathBuf,
     pub content: FileContent,
 }
 
+/// Represents the possible errors that can occur when working with [File] structs.
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum FileError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
@@ -47,11 +64,11 @@ impl Display for File {
 }
 
 impl File {
-    /// Instantiates a [File] and loads its content into memory, detecting its encoding in the process.
-    pub fn new(path: impl Into<PathBuf>, mut input: impl std::io::Read) -> Result<File, Error> {
+    /// Create a [File] with the given path and read it's content from the input [std::io::Read].
+    /// The encoding is detected as we read the content, and the appropriate [FileContent] is used.
+    pub fn new(path: impl Into<PathBuf>, mut input: impl std::io::Read) -> Result<Self, FileError> {
         let mut bytes: Vec<u8> = vec![];
         input.read_to_end(&mut bytes)?;
-
         let path = path.into();
         let content = TextData::try_from(bytes.as_slice());
         let content = if let Ok(content) = content {
@@ -63,24 +80,16 @@ impl File {
         Ok(File { path, content })
     }
 
-    /// Save the content of a file to disk, using the appropriate encoding for the content.
-    pub fn save(&self) -> Result<(), std::io::Error> {
-        match &self.content {
-            FileContent::Encoded { content } => fs::write(
-                &self.path,
-                match content.encoding {
-                    Encoding::Utf8 => content.data.as_bytes().to_vec(),
-                    Encoding::Utf8WithBom => decode_utf8_with_bom(&content.data),
-                    Encoding::Utf16Be => decode_utf16be(&content.data),
-                    Encoding::Utf16Le => decode_utf16le(&content.data),
-                },
-            )?,
-            FileContent::Binary { content } => {
-                fs::write(&self.path, content)?;
-            }
-        };
+    pub fn new_from_path(path: impl Into<PathBuf>) -> Result<Self, FileError> {
+        let path = path.into();
+        let reader = std::fs::File::open(&path)?;
+        Self::new(path, reader)
+    }
 
-        Ok(())
+    /// Save the content of a file to disk at it's [PathBuf], using the current encoding for the content.
+    pub fn save_to_path(&self) -> Result<(), std::io::Error> {
+        let mut writer = fs::File::create(&self.path)?;
+        self.content.write(&mut writer)
     }
 }
 
@@ -107,7 +116,7 @@ mod tests {
     ));
 
     #[test_case(b"Hello!", Encoding::Utf8)]
-    #[test_case(UTF8BOM_ASCII_CONTENT, Encoding::Utf8WithBom)]
+    #[test_case(UTF8BOM_ASCII_CONTENT, Encoding::Utf8Bom)]
     #[test_case(UTF16BE_ASCII_CONTENT, Encoding::Utf16Be)]
     #[test_case(UTF16LE_ASCII_CONTENT, Encoding::Utf16Le)]
     fn load_from_encoded_content(bytes: &[u8], encoding: Encoding) {

--- a/src/text_data.rs
+++ b/src/text_data.rs
@@ -33,7 +33,7 @@ impl TryFrom<&[u8]> for TextData {
         if bytes.starts_with(UTF8_BOM) {
             Ok(TextData {
                 data: String::from_utf8(bytes[UTF8_BOM_LENGTH..].to_vec())?,
-                encoding: Encoding::Utf8WithBom,
+                encoding: Encoding::Utf8Bom,
             })
         } else if bytes.starts_with(UTF16BE_BOM) {
             Ok(TextData {
@@ -143,7 +143,7 @@ mod tests {
         let subject = TextData::try_from(bytes).expect("Should pass");
         let expected = TextData {
             data: content.into(),
-            encoding: Encoding::Utf8WithBom,
+            encoding: Encoding::Utf8Bom,
         };
 
         assert_eq!(subject, expected);

--- a/tests/file_tests.rs
+++ b/tests/file_tests.rs
@@ -8,7 +8,7 @@ mod file_io_tests {
     const ENCODED_FILES_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data");
 
     #[test_case("UTF8/unicode", Encoding::Utf8; "UTF-8")]
-    #[test_case("UTF8BOM/unicode", Encoding::Utf8WithBom; "UTF-8WithBom")]
+    #[test_case("UTF8BOM/unicode", Encoding::Utf8Bom; "UTF-8WithBom")]
     #[test_case("UTF16BE/unicode", Encoding::Utf16Be; "UTF-16BE")]
     #[test_case("UTF16LE/unicode", Encoding::Utf16Le; "UTF-16LE")]
     fn save_encoded_content(path: &str, encoding: Encoding) -> anyhow::Result<()> {
@@ -26,7 +26,7 @@ mod file_io_tests {
             },
         };
 
-        file_content.save()?;
+        file_content.save_to_path()?;
 
         let bytes_after_saving = fs::read(&path)?;
 
@@ -47,7 +47,7 @@ mod file_io_tests {
             },
         };
 
-        file_content.save()?;
+        file_content.save_to_path()?;
 
         let bytes_after_saving = fs::read(&path)?;
 


### PR DESCRIPTION
This PR does some general clean up around names and notably moves `File::save` to be `File::save_to_path`, and moves the generic action of writing `FileContent` content to a writer by moving that logic to `FileContent::write`.