### PR TITLE
[deploy] 0.1.0 - add cargo registry env var from GH repo secret

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -26,3 +26,5 @@ jobs:
     - name: Publish
       if: steps.check_commit.outputs.deploy == 'true'
       run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The secret needs to be mapped into the publish task via env var.