### PR TITLE
[deploy] 0.2.0 - expose FileError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-content"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "A library for working with files and common text data encodings."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ mod utf16;
 pub use encoding::Encoding;
 pub use file::File;
 pub use file::FileContent;
+pub use file::FileError;
 pub use text_data::TextData;
 pub use text_data::TextDataError;


### PR DESCRIPTION
The FileError should also be exposed so consumers can make decisions when creating a `File` fails.