### PR TITLE
[deploy] 0.3.0 - Add helper methods for read_to_string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-content"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "A library for working with files and common text data encodings."

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -1,14 +1,20 @@
+use std::path::PathBuf;
+
 use anyhow::anyhow;
 use file_content::File;
 
 fn main() -> anyhow::Result<()> {
-    let file = std::env::args()
+    let path = std::env::args()
         .nth(1)
         .ok_or_else(|| anyhow!("Usage: read_file <file>"))?;
 
-    let file = File::new_from_path(file)?;
+    let path = PathBuf::from(path);
+    let file = File::new_from_path(&path)?;
 
-    println!("{}", file);
+    println!("{file}");
+
+    let content = file_content::read_to_string_from_path(&path)?;
+    println!("{content}");
 
     Ok(())
 }

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -13,7 +13,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("{file}");
 
-    let content = file_content::read_to_string_from_path(&path)?;
+    let content = file_content::read_to_string(&path)?;
     println!("{content}");
 
     Ok(())

--- a/src/file.rs
+++ b/src/file.rs
@@ -99,14 +99,14 @@ impl File {
 }
 
 /// Read the content and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
-pub fn read_to_string(input: impl Read) -> Result<String, FileError> {
+pub fn read(input: impl Read) -> Result<String, FileError> {
     read_to_text_data(input).map(|content| content.data)
 }
 
 /// Read the contents of a file from the given path and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
-pub fn read_to_string_from_path(path: impl AsRef<Path>) -> Result<String, FileError> {
+pub fn read_to_string(path: impl AsRef<Path>) -> Result<String, FileError> {
     let file = fs::File::open(path)?;
-    read_to_string(file)
+    read(file)
 }
 
 /// Read the content and return as a [TextData] if it can be decoded as one of the supported encodings from [Encoding].

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,7 +2,7 @@ use std::{
     fmt::Display,
     fs,
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use crate::{
@@ -101,6 +101,12 @@ impl File {
 /// Read the content and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
 pub fn read_to_string(input: impl Read) -> Result<String, FileError> {
     read_to_text_data(input).map(|content| content.data)
+}
+
+/// Read the contents of a file from the given path and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
+pub fn read_to_string_from_path(path: impl AsRef<Path>) -> Result<String, FileError> {
+    let file = fs::File::open(path)?;
+    read_to_string(file)
 }
 
 /// Read the content and return as a [TextData] if it can be decoded as one of the supported encodings from [Encoding].

--- a/src/file.rs
+++ b/src/file.rs
@@ -99,21 +99,16 @@ impl File {
 }
 
 /// Read the content and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
-pub fn read(input: impl Read) -> Result<String, FileError> {
-    read_to_text_data(input)?.data
+pub fn read_from_reader(mut input: impl Read) -> Result<String, FileError> {
+    let mut bytes = vec![];
+    input.read_to_end(&mut bytes)?;
+    let text_data = TextData::try_from(bytes.as_slice())?;
+    Ok(text_data.data)
 }
 
 /// Read the contents of a file from the given path and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
 pub fn read_to_string(path: impl AsRef<Path>) -> Result<String, FileError> {
-    let file = fs::File::open(path)?;
-    read(file)
-}
-
-/// Read the content and return as a [TextData] if it can be decoded as one of the supported encodings from [Encoding].
-pub fn read_to_text_data(mut input: impl Read) -> Result<TextData, FileError> {
-    let mut bytes: Vec<u8> = vec![];
-    input.read_to_end(&mut bytes)?;
-    Ok(TextData::try_from(bytes.as_slice())?)
+    Ok(TextData::try_from(path.as_ref())?.data)
 }
 
 #[cfg(test)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,9 @@
-use std::{fmt::Display, fs, io::Write, path::PathBuf};
+use std::{
+    fmt::Display,
+    fs,
+    io::{Read, Write},
+    path::PathBuf,
+};
 
 use crate::{
     encoding::{to_utf16_be, to_utf16_le, to_utf8_bom, Encoding},
@@ -91,6 +96,18 @@ impl File {
         let mut writer = fs::File::create(&self.path)?;
         self.content.write(&mut writer)
     }
+}
+
+/// Read the content and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
+pub fn read_to_string(input: impl Read) -> Result<String, FileError> {
+    read_to_text_data(input).map(|content| content.data)
+}
+
+/// Read the content and return as a [TextData] if it can be decoded as one of the supported encodings from [Encoding].
+pub fn read_to_text_data(mut input: impl Read) -> Result<TextData, FileError> {
+    let mut bytes: Vec<u8> = vec![];
+    input.read_to_end(&mut bytes)?;
+    Ok(TextData::try_from(bytes.as_slice())?)
 }
 
 #[cfg(test)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -100,7 +100,7 @@ impl File {
 
 /// Read the content and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].
 pub fn read(input: impl Read) -> Result<String, FileError> {
-    read_to_text_data(input).map(|content| content.data)
+    read_to_text_data(input)?.data
 }
 
 /// Read the contents of a file from the given path and return as a [String] if it can be decoded as one of the supported encodings from [Encoding].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,8 @@ mod text_data;
 mod utf16;
 
 pub use encoding::Encoding;
-pub use file::read;
+pub use file::read_from_reader;
 pub use file::read_to_string;
-pub use file::read_to_text_data;
 pub use file::File;
 pub use file::FileContent;
 pub use file::FileError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod utf16;
 
 pub use encoding::Encoding;
 pub use file::read_to_string;
+pub use file::read_to_string_from_path;
 pub use file::read_to_text_data;
 pub use file::File;
 pub use file::FileContent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ mod text_data;
 mod utf16;
 
 pub use encoding::Encoding;
+pub use file::read;
 pub use file::read_to_string;
-pub use file::read_to_string_from_path;
 pub use file::read_to_text_data;
 pub use file::File;
 pub use file::FileContent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ mod text_data;
 mod utf16;
 
 pub use encoding::Encoding;
+pub use file::read_to_string;
+pub use file::read_to_text_data;
 pub use file::File;
 pub use file::FileContent;
 pub use file::FileError;

--- a/src/text_data.rs
+++ b/src/text_data.rs
@@ -1,9 +1,14 @@
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
 use crate::constants::{
     BINARY_DETECTION_THRESHOLD, UTF16BE_BOM, UTF16LE_BOM, UTF16_BOM_LENGTH, UTF8_BOM,
     UTF8_BOM_LENGTH, ZERO_BYTE,
 };
 use crate::encoding::Encoding;
 use crate::utf16::{to_u16_be, to_u16_le, UnevenByteSequenceError};
+use crate::FileError;
 
 #[derive(Debug, PartialEq)]
 pub struct TextData {
@@ -24,6 +29,17 @@ pub enum TextDataError {
 
     #[error("File content is binary")]
     Binary,
+}
+
+impl TryFrom<&Path> for TextData {
+    type Error = FileError;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let mut file = fs::File::open(path)?;
+        let mut bytes: Vec<u8> = vec![];
+        file.read_to_end(&mut bytes)?;
+        Ok(TextData::try_from(bytes.as_slice())?)
+    }
 }
 
 impl TryFrom<&[u8]> for TextData {


### PR DESCRIPTION
This PR adds 3 small helper methods for scenarios where one doesn't really care about the actual encoding, or if the file was binary or not. Only if it can be parsed into a String.

* `read_to_string` - like `std::fs::read_to_string`
* `read_from_reader` - same return type as `read_to_string` but takes an `impl Read`.
* Add a `TryFrom<&Path> for TextData`
