### PR TITLE
[deploy] 0.3.1 - Add crates.io version badge to README and add missing docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-content"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Microsoft Corporation"]
 edition = "2021"
 description = "A library for working with files and common text data encodings."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # `file-content` 
 
-![Crates.io Version](https://img.shields.io/crates/v/file-content?style=for-the-badge&color=blue)
+| Crates.io | Docs |
+|-----------|------|
+[![Crates.io Version](https://img.shields.io/crates/v/file-content?style=for-the-badge&color=blue)](https://crates.io/crates/file-content) | [docs.rs/file-content](https://docs.rs/file-content/latest/file_content/) |
 
-A small library for reading file content/text data from disk, or anywhere else.
+A small library for reading file content/text data from disk, or anywhere else, into a `String`.
 
 ## Supported Encodings
 * `UTF-8`
@@ -26,13 +28,17 @@ use anyhow::anyhow;
 use file_content::File;
 
 fn main() -> anyhow::Result<()> {
-    let file = std::env::args()
+    let file_path = std::env::args()
         .nth(1)
         .ok_or_else(|| anyhow!("Usage: read_file <file>"))?;
 
-    let file = File::new_from_path(file)?;
+    let file: File = File::new_from_path(&file_path)?;
 
-    println!("{}", file);
+    println!("{:?}", file);
+
+    let content_only: String = file_content::read_to_string(&file_path)?;
+
+    println!("{content_only}");
 
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# `file-content`
+# `file-content` 
+
+![Crates.io Version](https://img.shields.io/crates/v/file-content?style=for-the-badge&color=blue)
 
 A small library for reading file content/text data from disk, or anywhere else.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # `file-content` 
 
-| Crates.io | Docs |
-|-----------|------|
-[![Crates.io Version](https://img.shields.io/crates/v/file-content?style=for-the-badge&color=blue)](https://crates.io/crates/file-content) | [docs.rs/file-content](https://docs.rs/file-content/latest/file_content/) |
+[![Crates.io Version](https://img.shields.io/crates/v/file-content?style=for-the-badge&color=blue)](https://crates.io/crates/file-content)  [![docs.rs](https://img.shields.io/docsrs/file-content?style=for-the-badge&color=green)
+](https://docs.rs/file-content/latest/file_content/)
 
 A small library for reading file content/text data from disk, or anywhere else, into a `String`.
 

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -1,20 +1,18 @@
-use std::path::PathBuf;
-
 use anyhow::anyhow;
 use file_content::File;
 
 fn main() -> anyhow::Result<()> {
-    let path = std::env::args()
+    let file_path = std::env::args()
         .nth(1)
         .ok_or_else(|| anyhow!("Usage: read_file <file>"))?;
 
-    let path = PathBuf::from(path);
-    let file = File::new_from_path(&path)?;
+    let file: File = File::new_from_path(&file_path)?;
 
-    println!("{file}");
+    println!("{:?}", file);
 
-    let content = file_content::read_to_string(&path)?;
-    println!("{content}");
+    let content_only: String = file_content::read_to_string(&file_path)?;
+
+    println!("{content_only}");
 
     Ok(())
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -10,6 +10,11 @@ use crate::{
     text_data::TextData,
 };
 
+/// An enum that represents the possible contents of a file
+/// 
+/// - `Encoded`: The content is a string that can be decoded as one of the
+/// supported encodings from [Encoding] (held in a [TextData])
+/// - `Binary`: The content is a sequence of bytes that cannot be decoded as a string
 #[derive(Debug, PartialEq)]
 pub enum FileContent {
     Encoded { content: TextData },

--- a/src/text_data.rs
+++ b/src/text_data.rs
@@ -10,12 +10,14 @@ use crate::encoding::Encoding;
 use crate::utf16::{to_u16_be, to_u16_le, UnevenByteSequenceError};
 use crate::FileError;
 
+/// A struct to hold the data of a text file and the encoding used to read it.
 #[derive(Debug, PartialEq)]
 pub struct TextData {
     pub data: String,
     pub encoding: Encoding,
 }
 
+/// The possible errors that can occur when working with [TextData] structs.
 #[derive(Debug, thiserror::Error)]
 pub enum TextDataError {
     #[error(transparent)]


### PR DESCRIPTION
# Docs Updates

* Add badges to the readme from shields.io that renders the current published version.

![Crates.io Version](https://img.shields.io/crates/v/file-content?style=for-the-badge&color=blue) ![docs.rs](https://img.shields.io/docsrs/file-content?style=for-the-badge)


* Add missing doc comments on pub structs and enums
* Update Example `read_file.rs` to show usage of `read_to_string`.
